### PR TITLE
Add many module support as a comma separated list

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ contributions are welcomed! Drawing a single component from scratch takes less
 than 10 minutes, which is not much time. Please, send a pull-request for
 components you have created.
 
+When specifying multiple module libraries, the first library path to match a
+given footprint is used for rendering. The lookup order is the same you
+wrote the `<libraries>` list.
+
 ## Eagle Boards
 
 Boards from Eagle CAD are not supported directly now. You can import an Eagle

--- a/README.md
+++ b/README.md
@@ -26,18 +26,18 @@ separate repository: [PcbDraw-Lib](https://github.com/yaqwsx/PcbDraw-Lib).
 Usage of PcbDraw is simple, just run:
 
 ```.{bash}
-./pcbdraw.py <style> <library> <output_file> <input_file>
+./pcbdraw.py <style> <libraries> <output_file> <input_file>
 ```
 - `style` is a path to a JSON file containing board colours definition. Several
   example styles are in the styles directory.
-- `library` is a path to a directory containing module library. Modules are
+- `libraries` is a comma separated list of paths to directories containing module libraries. Modules are
   component footprints in SVG format.
 - `output_file` is a path to an output SVG file
 - `input_file` is a path to an `*.kicad_pcb` file
 
 The script will output several debug messages of KiCAD Python API you can
 ignore. I haven't found a way to disable them. If there is a missing module in
-the library, the script will output warning.
+the libraries, the script will output warning.
 
 There are several options for the script:
 


### PR DESCRIPTION
Hello, this PR adds support for several module paths as a comma seprated list:

`./pcbdraw.py <style> <libraries> <output_file> <input_file>`

Any comments are welcome ! Thanks