### PR TITLE
Add SetPlotOutlineMode(False)

### DIFF
--- a/pcbdraw.py
+++ b/pcbdraw.py
@@ -212,7 +212,11 @@ def get_board_substrate(board, colors):
     popt.SetOutputDirectory(tmp)
     popt.SetScale(1)
     popt.SetMirror(False)
-    popt.SetPlotOutlineMode(False)
+    try:
+        popt.SetPlotOutlineMode(False)
+    except:
+        # Method does not exist in older versions of KiCad
+        pass
     popt.SetTextMode(pcbnew.PLOTTEXTMODE_STROKE)
     for f, layers, _ in toPlot:
         pctl.OpenPlotfile(f, pcbnew.PLOT_FORMAT_SVG, f)

--- a/pcbdraw.py
+++ b/pcbdraw.py
@@ -212,6 +212,7 @@ def get_board_substrate(board, colors):
     popt.SetOutputDirectory(tmp)
     popt.SetScale(1)
     popt.SetMirror(False)
+    popt.SetPlotOutlineMode(False)
     popt.SetTextMode(pcbnew.PLOTTEXTMODE_STROKE)
     for f, layers, _ in toPlot:
         pctl.OpenPlotfile(f, pcbnew.PLOT_FORMAT_SVG, f)


### PR DESCRIPTION
Using (almost) latest devel version of KiCad, the output SVG file was populated with `polyline`s instead of `path`s. This PR fixes the problem where (I think), KiCad was adding another general outline to the plot.

Let me know if this breaks anything, I tested it with good results.