### PR TITLE
Fix for python3

### DIFF
--- a/pcbdraw.py
+++ b/pcbdraw.py
@@ -212,7 +212,10 @@ def read_svg_unique(filename):
         content = f.read()
     for i in ids:
         content = content.replace("#"+i, "#" + prefix + i)
-    root = etree.fromstring(content)
+    if (sys.version_info > (3, 0)):
+        root = etree.fromstring(bytes(content, 'utf-8'))
+    else:
+        root = etree.fromstring(content_byte)
     for el in root.getiterator():
         if "id" in el.attrib and el.attrib["id"] != "origin":
             el.attrib["id"] = prefix + el.attrib["id"]


### PR DESCRIPTION
This was missing when using with python3.

Now, it is adding the components. I'm going to update my .svg library now.

I just added a small capacitor to test because I still don't have other components.

![image](https://user-images.githubusercontent.com/1277920/57469605-6a275b80-725d-11e9-916c-1a49d3b14e9e.png)
