### PR TITLE
Fix memory leak in pcbnew (KiCad) libraries.

### DIFF
--- a/pcbdraw/pcbdraw.py
+++ b/pcbdraw/pcbdraw.py
@@ -483,12 +483,11 @@ def get_hole_mask(board):
         if module.GetPadCount() == 0:
             module = module.Next()
             continue
-        pad = module.Pads()
         try:
-            pad.GetPosition()
-        except:
-            # Newest nightly renames Pads to PadList
             pad = module.PadsList()
+        except AttributeError:
+            # Older interfase used Pads()
+            pad = module.Pads()
         while pad:
             pos = pad.GetPosition()
             padOrientation = pad.GetOrientation()


### PR DESCRIPTION
Calling Pads() is deprecated and leaks memory in DLIST_ITERATOR_WRAPPER
So we must first try PadsList(), and use Pads() only if it failed (old
API).