### PR TITLE
Make warning about back side components optional.

### DIFF
--- a/pcbdraw/pcbdraw.py
+++ b/pcbdraw/pcbdraw.py
@@ -531,7 +531,7 @@ def print_component(paths, lib, name, value, ref, pos, remapping={}):
         ref, lib, name, pos[0], pos[1], math.degrees(pos[2]), f if f else "Not found")
     print(msg)
 
-def component_from_library(lib, name, value, ref, pos, comp, highlight, silent):
+def component_from_library(lib, name, value, ref, pos, comp, highlight, silent, warn_back):
     if not name:
         return
     if comp["filter"] is not None and ref not in comp["filter"]:
@@ -539,7 +539,8 @@ def component_from_library(lib, name, value, ref, pos, comp, highlight, silent):
     f = get_model_file(comp["libraries"], lib, name, ref, comp["remapping"])
     if not f:
         if not silent:
-            print("Warning: component '{}' for footprint '{}' from library '{}' was not found".format(name, ref, lib))
+            if name[-5:] != '.back' or warn_back:
+                print("Warning: component '{}' for footprint '{}' from library '{}' was not found".format(name, ref, lib))
         if comp["placeholder"]:
             etree.SubElement(comp["container"], "rect", x=str(ki2dmil(pos[0]) - 150), y=str(ki2dmil(pos[1]) - 150),
                              width="300", height="300", style="fill:red;")
@@ -661,6 +662,7 @@ def main():
     parser.add_argument("-v", "--vcuts", action="store_true", help="Render V-CUTS on the Cmts.User layer")
     parser.add_argument("--silent", action="store_true", help="Silent warning messages about missing footprints")
     parser.add_argument("--dpi", help="DPI for bitmap output", type=int, default=300)
+    parser.add_argument("--warn-back", action="store_true", help="Show warnings about back footprints")
 
     args = parser.parse_args()
     args.libs = [adjust_lib_path(path) for path in args.libs.split(',')]
@@ -736,12 +738,12 @@ def main():
         board_cont.append(get_layers(board, style, [("vcut", [pcbnew.Cmts_User], process_board_substrate_layer)]))
 
     walk_components(board, args.back, lambda lib, name, val, ref, pos:
-        component_from_library(lib, name, val, ref, pos, components, highlight, args.silent))
+        component_from_library(lib, name, val, ref, pos, components, highlight, args.silent, args.warn_back))
 
     # make another pass for search, and if found, render the back side of the component
     # the function will search for file with extension ".back.svg"
     walk_components(board, not args.back, lambda lib, name, val, ref, pos:
-        component_from_library(lib, name+".back", val, ref, pos, components, highlight, args.silent))
+        component_from_library(lib, name+".back", val, ref, pos, components, highlight, args.silent, args.warn_back))
 
     if args.output.endswith(".svg") or args.output.endswith(".SVG"):
         document.write(args.output)

--- a/pcbdraw/pcbdraw.py
+++ b/pcbdraw/pcbdraw.py
@@ -531,7 +531,7 @@ def print_component(paths, lib, name, value, ref, pos, remapping={}):
         ref, lib, name, pos[0], pos[1], math.degrees(pos[2]), f if f else "Not found")
     print(msg)
 
-def component_from_library(lib, name, value, ref, pos, comp, highlight, silent, warn_back):
+def component_from_library(lib, name, value, ref, pos, comp, highlight, silent, no_warn_back):
     if not name:
         return
     if comp["filter"] is not None and ref not in comp["filter"]:
@@ -539,7 +539,7 @@ def component_from_library(lib, name, value, ref, pos, comp, highlight, silent, 
     f = get_model_file(comp["libraries"], lib, name, ref, comp["remapping"])
     if not f:
         if not silent:
-            if name[-5:] != '.back' or warn_back:
+            if name[-5:] != '.back' or not no_warn_back:
                 print("Warning: component '{}' for footprint '{}' from library '{}' was not found".format(name, ref, lib))
         if comp["placeholder"]:
             etree.SubElement(comp["container"], "rect", x=str(ki2dmil(pos[0]) - 150), y=str(ki2dmil(pos[1]) - 150),
@@ -662,7 +662,7 @@ def main():
     parser.add_argument("-v", "--vcuts", action="store_true", help="Render V-CUTS on the Cmts.User layer")
     parser.add_argument("--silent", action="store_true", help="Silent warning messages about missing footprints")
     parser.add_argument("--dpi", help="DPI for bitmap output", type=int, default=300)
-    parser.add_argument("--warn-back", action="store_true", help="Show warnings about back footprints")
+    parser.add_argument("--no-warn-back", action="store_true", help="Don't show warnings about back footprints")
 
     args = parser.parse_args()
     args.libs = [adjust_lib_path(path) for path in args.libs.split(',')]
@@ -738,12 +738,12 @@ def main():
         board_cont.append(get_layers(board, style, [("vcut", [pcbnew.Cmts_User], process_board_substrate_layer)]))
 
     walk_components(board, args.back, lambda lib, name, val, ref, pos:
-        component_from_library(lib, name, val, ref, pos, components, highlight, args.silent, args.warn_back))
+        component_from_library(lib, name, val, ref, pos, components, highlight, args.silent, args.no_warn_back))
 
     # make another pass for search, and if found, render the back side of the component
     # the function will search for file with extension ".back.svg"
     walk_components(board, not args.back, lambda lib, name, val, ref, pos:
-        component_from_library(lib, name+".back", val, ref, pos, components, highlight, args.silent, args.warn_back))
+        component_from_library(lib, name+".back", val, ref, pos, components, highlight, args.silent, args.no_warn_back))
 
     if args.output.endswith(".svg") or args.output.endswith(".SVG"):
         document.write(args.output)


### PR DESCRIPTION
Messages about missing *.back component images are emitted only if the
--warn-back command line option is specified.