### PR TITLE
Look for styles and footprints also in /usr/share/pcbdraw/

### DIFF
--- a/pcbdraw/pcbdraw.py
+++ b/pcbdraw/pcbdraw.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import sys
 import tempfile
+import sysconfig
 import numpy as np
 
 from wand.api import library
@@ -21,6 +22,7 @@ GLOBAL_DATA_DIR = '/usr/share/pcbdraw'
 STYLES_SUBDIR = 'styles'
 FOOTPRINTS_SUBDIR = 'footprints'
 PKG_BASE = os.path.dirname(__file__)
+data_path = [PKG_BASE]
 
 default_style = {
     "copper": "#417e5a",
@@ -616,14 +618,11 @@ def find_data_file(name, ext, subdir):
         name += ext
         if os.path.isfile(name):
             return name
-    # With the sources?
-    local_name = os.path.join(PKG_BASE, subdir, name)
-    if os.path.isfile(local_name):
-        return local_name
-    # System level?
-    global_name = os.path.join(GLOBAL_DATA_DIR, subdir, name)
-    if os.path.isfile(global_name):
-        return global_name
+    # Try in the data path
+    for p in data_path:
+        fn = os.path.join(p, subdir, name)
+        if os.path.isfile(fn):
+            return fn
     raise RuntimeError("Missing '" + subdir + "' " + name)
 
 def load_style(style_file):
@@ -659,13 +658,21 @@ def load_remapping(remap_file):
         raise RuntimeError("Cannot open remapping file " + remap_file)
 
 def adjust_lib_path(path):
-    base_local = os.path.join(PKG_BASE, FOOTPRINTS_SUBDIR)
-    base_global = os.path.join(GLOBAL_DATA_DIR, FOOTPRINTS_SUBDIR)
     if path == "default" or path == "kicad-default":
-        return [os.path.join(base_local, "KiCAD-base"), os.path.join(base_global, "KiCAD-base")]
+        return [os.path.join(p, FOOTPRINTS_SUBDIR, "KiCAD-base") for p in data_path]
     if path == "eagle-default":
-        return [os.path.join(base_local, "Eagle-export"), os.path.join(base_global, "Eagle-export")]
+        return [os.path.join(p, FOOTPRINTS_SUBDIR, "Eagle-export") for p in data_path]
     return [path]
+
+def setup_data_path():
+    global data_path
+    share = os.path.join('share', 'pcbdraw')
+    if os.name == 'posix':
+        data_path.append(os.path.join(sysconfig.get_path('data', 'posix_user'), share))
+        data_path.append(os.path.join(sysconfig.get_path('data', 'posix_prefix'), share))
+    elif os.name == 'nt':
+        data_path.append(os.path.join(sysconfig.get_path('data', 'nt_user'), share))
+        data_path.append(os.path.join(sysconfig.get_path('data', 'nt'), share))
 
 def main():
     parser = argparse.ArgumentParser()
@@ -689,6 +696,7 @@ def main():
     parser.add_argument("--dpi", help="DPI for bitmap output", type=int, default=300)
 
     args = parser.parse_args()
+    setup_data_path()
     libs = []
     for path in args.libs.split(','):
         libs.extend(adjust_lib_path(path))

--- a/pcbdraw/pcbdraw.py
+++ b/pcbdraw/pcbdraw.py
@@ -18,7 +18,6 @@ from wand.image import Image
 import pcbnew
 from lxml import etree
 
-GLOBAL_DATA_DIR = '/usr/share/pcbdraw'
 STYLES_SUBDIR = 'styles'
 FOOTPRINTS_SUBDIR = 'footprints'
 PKG_BASE = os.path.dirname(__file__)
@@ -667,12 +666,20 @@ def adjust_lib_path(path):
 def setup_data_path():
     global data_path
     share = os.path.join('share', 'pcbdraw')
+    entries = len(data_path)
+    scheme_names = sysconfig.get_scheme_names()
     if os.name == 'posix':
-        data_path.append(os.path.join(sysconfig.get_path('data', 'posix_user'), share))
-        data_path.append(os.path.join(sysconfig.get_path('data', 'posix_prefix'), share))
+        if 'posix_user' in scheme_names:
+            data_path.append(os.path.join(sysconfig.get_path('data', 'posix_user'), share))
+        if 'posix_prefix' in scheme_names:
+            data_path.append(os.path.join(sysconfig.get_path('data', 'posix_prefix'), share))
     elif os.name == 'nt':
-        data_path.append(os.path.join(sysconfig.get_path('data', 'nt_user'), share))
-        data_path.append(os.path.join(sysconfig.get_path('data', 'nt'), share))
+        if 'nt_user' in scheme_names:
+            data_path.append(os.path.join(sysconfig.get_path('data', 'nt_user'), share))
+        if 'nt' in scheme_names:
+            data_path.append(os.path.join(sysconfig.get_path('data', 'nt'), share))
+    if len(data_path) == entries:
+        data_path.append(os.path.join(sysconfig.get_path('data'), share))
 
 def main():
     parser = argparse.ArgumentParser()

--- a/pcbdraw/pcbdraw.py
+++ b/pcbdraw/pcbdraw.py
@@ -17,6 +17,9 @@ from wand.image import Image
 import pcbnew
 from lxml import etree
 
+GLOBAL_DATA_DIR = '/usr/share/pcbdraw'
+STYLES_SUBDIR = 'styles'
+FOOTPRINTS_SUBDIR = 'footprints'
 PKG_BASE = os.path.dirname(__file__)
 
 default_style = {
@@ -604,10 +607,31 @@ def svg_to_bitmap(infile, outfile, dpi=300):
         with open(outfile, "wb") as out:
             out.write(bin_blob)
 
+def find_data_file(name, ext, subdir):
+    if os.path.isfile(name):
+        return name
+    # Not a file here, needs extension?
+    ln = len(ext)
+    if name[-ln:] != ext:
+        name += ext
+        if os.path.isfile(name):
+            return name
+    # With the sources?
+    local_name = os.path.join(PKG_BASE, subdir, name)
+    if os.path.isfile(local_name):
+        return local_name
+    # System level?
+    global_name = os.path.join(GLOBAL_DATA_DIR, subdir, name)
+    if os.path.isfile(global_name):
+        return global_name
+    raise RuntimeError("Missing '" + subdir + "' " + name)
+
 def load_style(style_file):
-    STYLES = os.path.join(PKG_BASE, "styles")
     if style_file.startswith("builtin:"):
+        STYLES = os.path.join(PKG_BASE, "styles")
         style_file = os.path.join(STYLES, style_file[len("builtin:"):])
+    else:
+        style_file = find_data_file(style_file, '.json', STYLES_SUBDIR)
     try:
         with open(style_file, "r") as f:
             style = json.load(f)
@@ -635,11 +659,13 @@ def load_remapping(remap_file):
         raise RuntimeError("Cannot open remapping file " + remap_file)
 
 def adjust_lib_path(path):
+    base_local = os.path.join(PKG_BASE, FOOTPRINTS_SUBDIR)
+    base_global = os.path.join(GLOBAL_DATA_DIR, FOOTPRINTS_SUBDIR)
     if path == "default" or path == "kicad-default":
-        return os.path.join(PKG_BASE, "footprints", "KiCAD-base")
+        return [os.path.join(base_local, "KiCAD-base"), os.path.join(base_global, "KiCAD-base")]
     if path == "eagle-default":
-        return os.path.join(PKG_BASE, "footprints", "Eagle-export")
-    return path
+        return [os.path.join(base_local, "Eagle-export"), os.path.join(base_global, "Eagle-export")]
+    return [path]
 
 def main():
     parser = argparse.ArgumentParser()
@@ -663,7 +689,10 @@ def main():
     parser.add_argument("--dpi", help="DPI for bitmap output", type=int, default=300)
 
     args = parser.parse_args()
-    args.libs = [adjust_lib_path(path) for path in args.libs.split(',')]
+    libs = []
+    for path in args.libs.split(','):
+        libs.extend(adjust_lib_path(path))
+    args.libs = libs
     args.highlight = args.highlight.split(',') if args.highlight is not None else []
     args.filter = args.filter.split(',') if args.filter is not None else None
 


### PR DESCRIPTION
This decouples the scripts from their data.
Data can be installed in GLOBAL_DATA_DIR (/usr/share/pcbdraw/)
Footprints:
- In addition to use PKG_BASE for default libs now we also look on
  GLOBAL_DATA_DIR
Styles:
- We try in the current directory.
- Then we try to add '.json' extension and look again.
- Try in PKG_BASE
- Finally try with GLOBAL_DATA_DIR
The "builtin:" mechanism bypass the search and goes straight to
PKG_BASE