### PR TITLE
Run populate.py without installing

### DIFF
--- a/pcbdraw/populate.py
+++ b/pcbdraw/populate.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+import sys
+import os
+PKG_BASE = os.path.dirname(__file__)
+# Give more priority to local modules than installed versions
+sys.path.insert(0, os.path.dirname(os.path.abspath(PKG_BASE)))
 
 import mistune
 import pcbdraw.mdrenderer
@@ -7,8 +12,6 @@ import codecs
 import pybars
 import yaml
 import argparse
-import sys
-import os
 import subprocess
 from copy import deepcopy
 
@@ -183,7 +186,9 @@ def generate_images(content, boardfilename, libs, parameters, name, outdir):
     return content
 
 def generate_image(boardfilename, libs, side, components, active, parameters, outputfile):
-    command = ["pcbdraw", "-f", ",".join(components), "-a", ",".join(active)]
+    # Use the pcbdraw.py script from the same point this script was executed
+    script = os.path.join(PKG_BASE, "pcbdraw.py")
+    command = ['python3', script, "-f", ",".join(components), "-a", ",".join(active)]
     if side.startswith("back"):
         command.append("-b")
     command += flatten(map(lambda x: x.split(" ", 1), parameters))


### PR DESCRIPTION
Now we load the mrenderer module and pcbdraw from the same directory
where populate.py is located.
In this way there is no need to install the scripts.
Neither we need to create symbolic links to run the work in progress
code.