### PR TITLE
Use yaml.safe_load instead of yaml.load

### DIFF
--- a/pcbdraw/populate.py
+++ b/pcbdraw/populate.py
@@ -131,7 +131,7 @@ def load_content(filename):
         if content.startswith("---"):
             end = content.find("...")
             if end != -1:
-                header = yaml.load(content[3:end], Loader=yaml.FullLoader)
+                header = yaml.safe_load(content[3:end])
                 content = content[end+3:]
     return header, content
 


### PR DESCRIPTION
There two reasons for this:
- The Debian stable version of PyYAML doesn't have yaml.FullLoader
- I think is better to use the safe version for a configuration file.
  We are not using YAML for persistence.