### PR TITLE
Remap invisible components from the example to dummy.

### DIFF
--- a/examples/pcbdraw/remap.json
+++ b/examples/pcbdraw/remap.json
@@ -3,5 +3,8 @@
     "L_B1": "LEDs:LED-5MM_blue",
     "L_Y1": "LEDs:LED-5MM_yellow",
     "PHOTO1": "yaqwsx:R_PHOTO_7mm",
-    "J8": "yaqwsx:Pin_Header_Straight_1x02_circle"
+    "J8": "yaqwsx:Pin_Header_Straight_1x02_circle",
+    "REF**": "dummy:dummy",
+    "G***": "dummy:dummy",
+    "svg2mod": "dummy:dummy"
 }


### PR DESCRIPTION
This removes all the useless warnings about missing components that are
already rendered in other layers.
This patch is related to yaqwsx/PcbDraw-Lib#7