### PR TITLE
Add OSHPark After Dark style

### DIFF
--- a/pcbdraw/styles/oshpark-afterdark.json
+++ b/pcbdraw/styles/oshpark-afterdark.json
@@ -1,0 +1,13 @@
+{
+    "copper": "#af6640",
+    "board": "#323232",
+    "silk": "#d8dae7",
+    "pads": "#dec500",
+    "clad": "#5d4e44",
+    "outline": "#000000",
+    "vcut": "#f0f0f0",
+    "highlight-on-top": false,
+    "highlight-style": "stroke:none;fill:#ff0000;opacity:0.5;",
+    "highlight-padding": 1.5,
+    "highlight-offset": 0
+}


### PR DESCRIPTION
This just adds a new style that looks like oshpark's after dark renders


Example

![image](https://user-images.githubusercontent.com/20230450/90680708-93a5a400-e262-11ea-9c51-e44e73e639e7.png)
