### PR TITLE
Fix drawing PCBs without modules

### DIFF
--- a/pcbdraw/pcbdraw.py
+++ b/pcbdraw/pcbdraw.py
@@ -451,10 +451,8 @@ def get_board_substrate(board, colors, holes, back):
     return container
 
 def walk_components(board, back, export):
-    module = board.GetModules()
-    while True:
-        if not module:
-            return
+    module = board.GetModules().GetFirst()
+    while module:
         # Top is for Eagle boards imported to KiCAD
         if (str(module.GetLayerName()) in ["Back", "B.Cu"] and not  back) or \
            (str(module.GetLayerName()) in ["Top", "F.Cu"]  and      back):
@@ -486,7 +484,7 @@ def get_hole_mask(board):
     bg.attrib["width"] = str(ki2dmil(bb.GetWidth()))
     bg.attrib["height"] = str(ki2dmil(bb.GetHeight()))
 
-    module = board.GetModules()
+    module = board.GetModules().GetFirst()
     while module:
         if module.GetPadCount() == 0:
             module = module.Next()


### PR DESCRIPTION
Drawing PCB without modules (for example edges only) were causing crash due to module variable not being None (empty list):

``` bash
aws:PcbDraw/ (master✗) $ pcbdraw --filter "" test/test/test.kicad_pcb test.svg

> /home/aws/.local/lib/python3.9/site-packages/pcbdraw/pcbdraw.py(492)get_hole_mask()
-> if module.GetPadCount() == 0:
(Pdb) type(module)
<class 'pcbnew.MODULE_List'>
(Pdb) n
[1]    351541 segmentation fault (core dumped)  pcbdraw --filter "" test/test/test.kicad_pcb test.svg
```

Using pcbnew.MODULE_List.GetFirst() before iterating through elements seems to be fixing this issue.

Run once for empty board (outline only) and once for PCB with components and it is working.