### PR TITLE
Fixed zero return with ComputeBoundingBox

### DIFF
--- a/pcbdraw/pcbdraw.py
+++ b/pcbdraw/pcbdraw.py
@@ -430,6 +430,7 @@ def get_layers(board, colors, defs, toPlot):
                 pctl.SetLayer(l)
                 pctl.PlotLayer()
         pctl.ClosePlot()
+        board.SetVisibleAlls()
         boardsize = board.ComputeBoundingBox()
         for f, _, process in toPlot:
             for svg_file in os.listdir(tmp):
@@ -484,6 +485,7 @@ def get_board_substrate(board, colors, defs, holes, back):
                 pctl.SetLayer(l)
                 pctl.PlotLayer()
         pctl.ClosePlot()
+        board.SetVisibleAlls()
         boardsize = board.ComputeBoundingBox()
         for f, _, process in toPlot:
             for svg_file in os.listdir(tmp):
@@ -518,6 +520,7 @@ def get_hole_mask(board, defs):
     mask = etree.SubElement(defs, "mask", id="hole-mask")
     container = etree.SubElement(mask, "g")
 
+    board.SetVisibleAlls()
     bb = board.ComputeBoundingBox()
     bg = etree.SubElement(container, "rect", x="0", y="0", fill="white")
     bg.attrib["x"] = str(ki2svg(bb.GetX()))
@@ -880,6 +883,7 @@ def main():
                                         remapping=remapping))
         sys.exit(0)
 
+    board.SetVisibleAlls()
     bb = board.ComputeBoundingBox()
     transform_string = ""
     # Let me briefly explain what's going on. KiCAD outputs SVG in user units,


### PR DESCRIPTION
Without calling `board.SetVisibleAlls()`, at least on a certain board I was working on the bounding box will not be properly calculated (a 0 return), and the board will not be properly generated:

Before fix:  ![image](https://user-images.githubusercontent.com/15680882/146479875-bb484edb-1b6e-416e-afd3-5b26d2973069.png)

After fix: ![image](https://user-images.githubusercontent.com/15680882/146479835-cc95e44d-0c72-4fd7-bc88-c7f060cd62ed.png)

Related KiCad issue: https://gitlab.com/kicad/code/kicad/-/issues/9452
