### PR TITLE
Removed click as dependency, not really used.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setuptools.setup(
         "pybars3",
         "wand",
         "pyyaml",
-        "click",
         "svgpathtools",
         "pcbnewTransition>=0.2"
     ],


### PR DESCRIPTION
The project isn't using click, so we can remove it from the dependencies.