### PR TITLE
Reverted #77

### DIFF
--- a/pcbdraw/pcbdraw.py
+++ b/pcbdraw/pcbdraw.py
@@ -430,7 +430,6 @@ def get_layers(board, colors, defs, toPlot):
                 pctl.SetLayer(l)
                 pctl.PlotLayer()
         pctl.ClosePlot()
-        board.SetVisibleAlls()
         boardsize = board.ComputeBoundingBox()
         for f, _, process in toPlot:
             for svg_file in os.listdir(tmp):
@@ -485,7 +484,6 @@ def get_board_substrate(board, colors, defs, holes, back):
                 pctl.SetLayer(l)
                 pctl.PlotLayer()
         pctl.ClosePlot()
-        board.SetVisibleAlls()
         boardsize = board.ComputeBoundingBox()
         for f, _, process in toPlot:
             for svg_file in os.listdir(tmp):
@@ -520,7 +518,6 @@ def get_hole_mask(board, defs):
     mask = etree.SubElement(defs, "mask", id="hole-mask")
     container = etree.SubElement(mask, "g")
 
-    board.SetVisibleAlls()
     bb = board.ComputeBoundingBox()
     bg = etree.SubElement(container, "rect", x="0", y="0", fill="white")
     bg.attrib["x"] = str(ki2svg(bb.GetX()))
@@ -883,7 +880,6 @@ def main():
                                         remapping=remapping))
         sys.exit(0)
 
-    board.SetVisibleAlls()
     bb = board.ComputeBoundingBox()
     transform_string = ""
     # Let me briefly explain what's going on. KiCAD outputs SVG in user units,


### PR DESCRIPTION
As it turns out, the `ComputeBoundingBox` returning zero was actually a bug in KiCAD, and the reply from https://gitlab.com/kicad/code/kicad/-/issues/9452 was a misintepretation/oversight. I did trace the bug eventually and reported it (https://gitlab.com/kicad/code/kicad/-/issues/10179). 

This should be now fixed in KiCAD >6.0.1, so setting all visible is no longer necessary. One consequence of setting everything  visible thought as a fix is that it also set dimension layers visible for example, so `Populate` would draw the SVG on the generated webpage to be the wrong size