### PR TITLE
Fix THT Resistor Color Related Code + Style Loading

### DIFF
--- a/pcbdraw/plot.py
+++ b/pcbdraw/plot.py
@@ -864,14 +864,14 @@ class PlotComponents:
         if root.find(f".//*[@id='{id_prefix}res_band1']") is None:
             return
         try:
-            res, tolerance = get_resistance_from_value(value)
+            res, tolerance = self._get_resistance_from_value(value)
             power = math.floor(res.log10()) - 1
             res = int(res / 10 ** power)
             resistor_colors = [
-                self._plotter._get_style("tht-resistor-band-colors", int(str(res)[0])),
-                self._plotter._get_style("tht-resistor-band-colors", int(str(res)[1])),
-                self._plotter._get_style("tht-resistor-band-colors", int(power)),
-                self._plotter._get_style("tht-resistor-band-colors", tolerance)
+                self._plotter.get_style("tht-resistor-band-colors", int(str(res)[0])),
+                self._plotter.get_style("tht-resistor-band-colors", int(str(res)[1])),
+                self._plotter.get_style("tht-resistor-band-colors", int(power)),
+                self._plotter.get_style("tht-resistor-band-colors", tolerance)
             ]
 
             if ref in self.resistor_values:

--- a/pcbdraw/plot.py
+++ b/pcbdraw/plot.py
@@ -1088,11 +1088,11 @@ class PcbPlotter():
         """
         Given a name of style, find the corresponding file and load it
         """
-        path = self._find_data_file(name, ".json", "styles")
+        path = self._find_data_file(name, ".json", "resources/styles")
         if path is None:
             raise RuntimeError(f"Cannot locate resource {name}; explored paths:\n"
                 + "\n".join([f"- {x}" for x in self.data_path]))
-        self.style = load_style(name)
+        self.style = load_style(path)
 
     def _find_data_file(self, name: str, extension: str, subdir: str) -> Optional[str]:
         return find_data_file(name, extension, self.data_path, subdir)

--- a/pcbdraw/ui.py
+++ b/pcbdraw/ui.py
@@ -183,7 +183,7 @@ def build_plot_components(remap, highlight, filter, resistor_flip, resistor_valu
         key, value = tuple(mapping.split(":"))
         resistor_values[key] = ResistorValue(value=value)
     for ref in resistor_flip:
-        field = resistor_values.get(key, ResistorValue())
+        field = resistor_values.get(ref, ResistorValue())
         field.flip_bands = True
         resistor_values[ref] = field
 


### PR DESCRIPTION
This PR fixes an issue with wrong callback functions in `plot.py` where it finds the values and colors for a THT resistor, and fixes the variable name used in `ui.py` where it gets the resistor values to be flipped.

Also fixed the style loading code, where it still looked at the old path and the `load_style` function was given `name` instead of the found `path`