### PR TITLE
Adds support for numpy<1.20

### DIFF
--- a/pcbdraw/plot.py
+++ b/pcbdraw/plot.py
@@ -14,7 +14,10 @@ from decimal import Decimal
 from typing import Callable, Dict, List, Optional, Tuple, TypeVar, Union, Any
 
 import numpy as np
-import numpy.typing
+try:
+    import numpy.typing
+except ModuleNotFoundError:
+    pass
 from pcbdraw.unit import read_resistance
 import svgpathtools # type: ignore
 from lxml import etree, objectify # type: ignore
@@ -24,7 +27,8 @@ from pcbnewTransition import KICAD_VERSION, isV6, pcbnew # type: ignore
 T = TypeVar("T")
 Numeric = Union[int, float]
 Point = Tuple[Numeric, Numeric]
-Matrix = np.typing.NDArray[np.float32]
+# Matrix = np.typing.NDArray[np.float32] Disabled because we not always have np.typing
+Matrix = Any
 Box = Tuple[Numeric, Numeric, Numeric, Numeric]
 
 

--- a/pcbdraw/renderer.py
+++ b/pcbdraw/renderer.py
@@ -12,7 +12,10 @@ from tempfile import TemporaryDirectory
 from typing import Callable, Dict, List, Optional, Tuple, Union, Any, Generator
 from pathlib import Path
 import numpy as np
-import numpy.typing
+try:
+    import numpy.typing
+except ModuleNotFoundError:
+    pass
 
 from PIL import Image, ImageChops, ImageDraw, ImageFilter
 from pyvirtualdisplay.smartdisplay import SmartDisplay


### PR DESCRIPTION
- The numpy.typing was introduced in 1.20.
- Current Debian stable uses 1.19.
- The numpy.typing functionality is currently needed only for tests (mypy), not for runtime