### PR TITLE
Fixes the missing shortcut for --filter (-f)

### DIFF
--- a/doc/pcbdraw.md
+++ b/doc/pcbdraw.md
@@ -34,7 +34,7 @@ has the following options:
 - `--mirror` Mirror the board
 - `--highlight COMMA SEPARATED LIST` Comma separated list of component
   designators to highlight
-- `--filter COMMA SEPARATED LIST` Comma separated list of component designators
+- `-f, --filter COMMA SEPARATED LIST` Comma separated list of component designators
   to show, if not specified, show all
 - `-v, --vcuts KICAD LAYER` If layer is specified, renders V-cuts from it
 - `--resistor-values COMMA SEPARATED LIST` Comma separated colon delimited

--- a/pcbdraw/ui.py
+++ b/pcbdraw/ui.py
@@ -100,7 +100,7 @@ class WarningStderrReporter:
     help="Mirror the board")
 @click.option("--highlight", type=CommaList(), default=[],
     help="Comma separated list of components to highlight")
-@click.option("--filter", type=CommaList(), default=None,
+@click.option("--filter", "-f", type=CommaList(), default=None,
     help="Comma separated list of components to show, if not specified, show all")
 @click.option("--vcuts", "-v", type=KiCADLayer(), default=None,
     help="If layer specified, renders V-cuts from it")


### PR DESCRIPTION
To keep it compatible with older versions that supported `-f`