### PR TITLE
Recover mistune 0.8.4 support.

### DIFF
--- a/pcbdraw/mdrenderer.py
+++ b/pcbdraw/mdrenderer.py
@@ -12,7 +12,12 @@
     :licence: WTFPL 2
 """
 
-from mistune.renderers import BaseRenderer  # type: ignore
+# The following try-catch is used to support mistune 0.8.4 and 2.x
+try:
+    from mistune.renderers import BaseRenderer  # type: ignore
+except ModuleNotFoundError:
+    from mistune import Renderer  # type: ignore
+    BaseRenderer = Renderer
 
 
 class MdRenderer(BaseRenderer):
@@ -42,6 +47,9 @@ class MdRenderer(BaseRenderer):
 
     def heading(self, text, level, raw=None):
         return '#'*level + " " + text + '\n\n'
+
+    # Mistune 0.8.4 calls it header, not heading
+    header = heading
 
     def paragraph(self, text):
         return text + '\n\n'


### PR DESCRIPTION
- mistune 2.x is incompatible with 0.8.4
- Debian stable uses 0.8.4, so installing 2.x at system level breaks all applications using mistune.
- The patch is small and the important code is shared between the two versions.