### PR TITLE
Allow copper to be disabled

### DIFF
--- a/pcbdraw/plot.py
+++ b/pcbdraw/plot.py
@@ -607,6 +607,7 @@ class PlotInterface:
 @dataclass
 class PlotSubstrate(PlotInterface):
     drill_holes: bool = True
+    copper: bool = True
     outline_width: int = mm2ki(0.1)
 
     def render(self, plotter: PcbPlotter) -> None:
@@ -617,22 +618,24 @@ class PlotSubstrate(PlotInterface):
             to_plot = [
                 PlotAction("board", [pcbnew.Edge_Cuts], self._process_baselayer),
                 PlotAction("clad", [pcbnew.B_Mask], self._process_layer),
-                PlotAction("copper", [pcbnew.B_Cu], self._process_layer),
                 PlotAction("pads", [pcbnew.B_Cu], self._process_layer),
                 PlotAction("pads-mask", [pcbnew.B_Mask], self._process_mask),
                 PlotAction("silk", [pcbnew.B_SilkS], self._process_layer),
                 PlotAction("outline", [pcbnew.Edge_Cuts], self._process_outline)
             ]
+            if self.copper:
+                to_plot.insert(2, PlotAction("copper", [pcbnew.B_Cu], self._process_layer))
         else:
             to_plot = [
                 PlotAction("board", [pcbnew.Edge_Cuts], self._process_baselayer),
                 PlotAction("clad", [pcbnew.F_Mask], self._process_layer),
-                PlotAction("copper", [pcbnew.F_Cu], self._process_layer),
                 PlotAction("pads", [pcbnew.F_Cu], self._process_layer),
                 PlotAction("pads-mask", [pcbnew.F_Mask], self._process_mask),
                 PlotAction("silk", [pcbnew.F_SilkS], self._process_layer),
                 PlotAction("outline", [pcbnew.Edge_Cuts], self._process_outline)
             ]
+            if self.copper:
+                to_plot.insert(2, PlotAction("copper", [pcbnew.F_Cu], self._process_layer))
 
         self._container = etree.Element("g", id="substrate")
         self._container.attrib["clip-path"] = "url(#cut-off)"

--- a/pcbdraw/ui.py
+++ b/pcbdraw/ui.py
@@ -119,6 +119,8 @@ class WarningStderrReporter:
     help="Add paste layer")
 @click.option("--components/--no-components", default=True,
     help="Render components")
+@click.option("--copper/--no-copper", default=True,
+    help="Render copper")
 @click.option("--outline-width", type=float, default=0.15,
     help="Outline width in mm")
 @click.option("--show-lib-paths", is_flag=True,
@@ -128,7 +130,7 @@ def plot(input: str, output: str, style: Optional[str], libs: List[str],
          mirror: bool, highlight: List[str], filter: Optional[List[str]],
          vcuts: bool, dpi: int, margin: float, silent: bool, werror: bool,
          resistor_values: List[str], resistor_flip: List[str], components: bool,
-         paste: bool, outline_width: float, show_lib_paths: bool) -> int:
+         copper: bool, paste: bool, outline_width: float, show_lib_paths: bool) -> int:
     """
     Create a stylized drawing of the PCB.
     """
@@ -165,6 +167,7 @@ def plot(input: str, output: str, style: Optional[str], libs: List[str],
 
     plotter.plot_plan = [PlotSubstrate(
                             drill_holes=drill_holes,
+                            copper=copper,
                             outline_width=mm2ki(outline_width))]
     if paste:
         plotter.plot_plan.append(PlotPaste())


### PR DESCRIPTION
This pull request adds an option to disable rendering copper layers.

For many pin diagrams, having copper traces is unnecessary.

Example with copper:
![pcb_copper](https://github.com/yaqwsx/PcbDraw/assets/440158/076d57db-1948-4058-b554-021617512aeb)

Example without copper:
![pcb_nocopper](https://github.com/yaqwsx/PcbDraw/assets/440158/6edfa641-7166-4109-8ce2-62daa2f453a3)
