### PR TITLE
Pr 1k resistor crash (#152)

### DIFF
--- a/pcbdraw/plot.py
+++ b/pcbdraw/plot.py
@@ -1183,7 +1183,7 @@ class PcbPlotter():
                     value = value[key]
                 return value
             except KeyError as e:
-                raise e from None
+                raise UserWarning(f"Invalid argument for get_style : {args[0]}, {args[1]}")
 
     def execute_plot_plan(self, to_plot: List[PlotAction]) -> None:
         """

--- a/pcbdraw/plot.py
+++ b/pcbdraw/plot.py
@@ -929,6 +929,11 @@ class PlotComponents(PlotInterface):
                 if t_string.strip() not in s:
                     raise UserWarning(f"Invalid resistor tolerance {value_l[1]}")
                 tolerance = t_string
+            else:
+                try:
+                    res = read_resistance(value)
+                except ValueError:
+                    raise UserWarning(f"Invalid resistor value {value}")
         return res, tolerance
 
 

--- a/pcbdraw/plot.py
+++ b/pcbdraw/plot.py
@@ -57,6 +57,8 @@ default_style = {
     "highlight-padding": 1.5,
     "highlight-offset": 0,
     "tht-resistor-band-colors": {
+        -2: '#d9d9d9',
+        -1: '#ffc800',
         0: '#000000',
         1: '#805500',
         2: '#ff0000',
@@ -884,7 +886,7 @@ class PlotComponents(PlotInterface):
         try:
             res, tolerance = self._get_resistance_from_value(value)
             power = math.floor(res.log10()) - 1
-            res = Decimal(int(res / 10 ** power))
+            res = Decimal(int(float(res) / 10 ** power))
             resistor_colors = [
                 self._plotter.get_style("tht-resistor-band-colors", int(str(res)[0])),
                 self._plotter.get_style("tht-resistor-band-colors", int(str(res)[1])),


### PR DESCRIPTION
In file plot.py

In _get_resistance_from_value, an "improvement" 9 month ago was not handling correctly the cases like "1 k", "270 M" as long as there was a space in the format.

in _apply_resistor_code, the call of get_style if protected from UserWarning, but get style was sending another kind of exception