### PR TITLE
Populate Series of Components

### DIFF
--- a/pcbdraw/populate.py
+++ b/pcbdraw/populate.py
@@ -30,13 +30,15 @@ def parse_pcbdraw(lexer: Any, m: re.Match[str], state: Any=None) -> Any:
     for i in reversed(range(len(components))):
         c = components[i]
         if c.count('-') == 1:   # if we have a - for a range (for example R3-R9)
-            m = re.match(r'(\w*?)(\d+)-(\w*?)(\d+)$', c)
+            s_m = re.match(r'(\w*?)(\d+)-(\w*?)(\d+)$', c)
+            if s_m is None:
+                continue
             try:
-                prefix = m.group(1)
-                if prefix != m.group(3):    # if the first and second prefix don't match, ignore
+                prefix = s_m.group(1)
+                if prefix != s_m.group(3):    # if the first and second prefix don't match, ignore
                     continue
-                start_n = int(m.group(2))
-                end_n = int(m.group(4))
+                start_n = int(s_m.group(2))
+                end_n = int(s_m.group(4))
             except (IndexError, ValueError):
                 # if we either didn't have a full regex match, or the numbers weren't integers somehow?
                 continue

--- a/pcbdraw/populate.py
+++ b/pcbdraw/populate.py
@@ -27,26 +27,6 @@ def parse_pcbdraw(lexer: Any, m: re.Match[str], state: Any=None) -> Any:
     text = m.group(1)
     side, components = text.split("|")
     components = list(map(lambda x: x.strip(), components.split(",")))
-    for i in reversed(range(len(components))):
-        c = components[i]
-        if c.count('-') == 1:   # if we have a - for a range (for example R3-R9)
-            s_m = re.match(r'(\w*?)(\d+)-(\w*?)(\d+)$', c)
-            if s_m is None:
-                continue
-            try:
-                prefix = s_m.group(1)
-                if prefix != s_m.group(3):    # if the first and second prefix don't match, ignore
-                    continue
-                start_n = int(s_m.group(2))
-                end_n = int(s_m.group(4))
-            except (IndexError, ValueError):
-                # if we either didn't have a full regex match, or the numbers weren't integers somehow?
-                continue
-            if start_n > end_n:     # check that the first number is the lower limit (R6-R2 is not valid)
-                continue
-            # Replace XY-XZ with [XY, X(Y+1), X(Y+2), ..., X(Z-1), ZX]
-            components += [f"{prefix}{i}" for i in range(start_n, end_n+1)]
-            components.pop(i)
     return 'pcbdraw', side, components
 
 class PcbDrawInlineLexer(InlineParser): # type: ignore
@@ -253,13 +233,13 @@ def generate_image(boardfilename: str, side: str, components: List[str],
     plot_args += ["--filter", ",".join(components)]
     plot_args += ["--highlight", ",".join(active)]
     plot_args += [boardfilename, outputfile]
-    tmp_std = sys.stdout        # make a copy of stdout
+    tmp_std = sys.stdout        # make a copy of stdout in order to preserve it before Click overrides it
     try:
         plot.main(args=plot_args)
     except SystemExit as e:
         if e.code is not None and e.code != 0:
             raise e from None
-    sys.stdout = tmp_std
+    sys.stdout = tmp_std        # restore copied stdout for print statements to work
 
 def get_data_path() -> List[str]:
     paths: List[str] = []

--- a/pcbdraw/ui.py
+++ b/pcbdraw/ui.py
@@ -1,5 +1,6 @@
 import platform
 import sys
+import re
 from dataclasses import dataclass
 from enum import IntEnum
 from typing import Tuple, Optional, Any, List
@@ -68,6 +69,36 @@ class CommaList(click.ParamType):
         values = [x.strip() for x in value.split(",")]
         return values
 
+
+class CommaComponentList(CommaList):
+    name = "Comma separated component list, with optional ranges like R1-R20"
+
+    def convert(self, value: Any, param: Optional[click.Parameter],
+                ctx: Optional[click.Context]) -> List[str]:
+        values = super().convert(value, param, ctx)
+        for i in reversed(range(len(values))):
+            c = values[i]
+            if c.count('-') == 1:  # if we have a - for a range (for example R3-R9)
+                s_m = re.match(r'(\w*?)(\d+)-(\w*?)(\d+)$', c)
+                if s_m is None:
+                    continue
+                try:
+                    prefix = s_m.group(1)
+                    if prefix != s_m.group(3):  # if the first and second prefix don't match, ignore
+                        continue
+                    start_n = int(s_m.group(2))
+                    end_n = int(s_m.group(4))
+                except (IndexError, ValueError):
+                    # if we either didn't have a full regex match, or the numbers weren't integers somehow?
+                    continue
+                if start_n > end_n:  # check that the first number is the lower limit (R6-R2 is not valid)
+                    continue
+                # Replace XY-XZ with [XY, X(Y+1), X(Y+2), ..., X(Z-1), ZX]
+                values += [f"{prefix}{i}" for i in range(start_n, end_n + 1)]
+                values.pop(i)
+        return values
+
+
 @dataclass
 class WarningStderrReporter:
     silent: bool
@@ -99,9 +130,9 @@ class WarningStderrReporter:
     help="Specify which side of the PCB to render")
 @click.option("--mirror", is_flag=True,
     help="Mirror the board")
-@click.option("--highlight", type=CommaList(), default=[],
+@click.option("--highlight", type=CommaComponentList(), default=[],
     help="Comma separated list of components to highlight")
-@click.option("--filter", "-f", type=CommaList(), default=None,
+@click.option("--filter", "-f", type=CommaComponentList(), default=None,
     help="Comma separated list of components to show, if not specified, show all")
 @click.option("--vcuts", "-v", type=KiCADLayer(), default=None,
     help="If layer specified, renders V-cuts from it")
@@ -115,7 +146,7 @@ class WarningStderrReporter:
     help="Treat warnings as errors")
 @click.option("--resistor-values", type=CommaList(), default=[],
     help="Comma separated list of resistor value remapping. For example, \"R1:10k,R2:470\"")
-@click.option("--resistor-flip", type=CommaList(), default=[],
+@click.option("--resistor-flip", type=CommaComponentList(), default=[],
     help="Comma separated list of resistor bands to flip")
 @click.option("--paste", is_flag=True,
     help="Add paste layer")

--- a/pcbdraw/ui.py
+++ b/pcbdraw/ui.py
@@ -79,7 +79,7 @@ class CommaComponentList(CommaList):
         for i in reversed(range(len(values))):
             c = values[i]
             if c.count('-') == 1:  # if we have a - for a range (for example R3-R9)
-                s_m = re.match(r'(\w*?)(\d+)-(\w*?)(\d+)$', c)
+                s_m = re.match(r'([a-zA-Z]+?)(\d+)-([a-zA-Z]+?)(\d+)$', c)
                 if s_m is None:
                     continue
                 try:


### PR DESCRIPTION
This PR adds the ability for `populate` to take a series of components with a start and end reference delimited with a `-`, and use all the ones in between. 

For example, `R3-R20` will be treated like `R3,R4,R5...R19,R20`

This PR also makes a copy of stdout and replaces it back. This is because during debugging, I noticed that when the click application is called, stdout no longer points to the terminal's stdout after the execution is completed.