### PR TITLE
Add deprecated configparser methods fallback

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -339,9 +339,18 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+
+    if hasattr(configparser, 'SafeConfigParser') and callable(getattr(configparser, 'SafeConfigParser')):
+        parser = configparser.SafeConfigParser()
+    else:
+        parser = configparser.ConfigParser()
+
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        if hasattr(parser, 'readfp') and callable(getattr(parser, 'readfp')):
+            parser.readfp(f)
+        else:
+            parser.read_file(f)
+
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
The latest version of `configparser` (python 3.12) removes the method `SafeConfigParser` and `readfp` in favor of `ConfigParser` and `read_file` respectively.